### PR TITLE
Fix the button misalignment in the modal sheet

### DIFF
--- a/Sources/ConcentricOnboarding/Helpers/AnimatableShape.swift
+++ b/Sources/ConcentricOnboarding/Helpers/AnimatableShape.swift
@@ -35,11 +35,11 @@ struct AnimatableShape: Shape {
         if type == .growing {
             r = CGFloat(radius + pow(2, progress))
             delta = CGFloat((1 - progress / limit) * radius)
-            center = CGPoint(x: UIScreen.main.bounds.width / 2 + r - delta - 2.0, y: UIScreen.main.bounds.height / 2)
+            center = CGPoint(x: UIScreen.main.bounds.width / 2 + r - delta - 2.0, y: rect.height / 2)
         } else {
             r = CGFloat(radius + pow(2, (limit - progress)))
             delta = CGFloat((progress / limit) * radius)
-            center = CGPoint(x: UIScreen.main.bounds.width / 2 - r + delta, y: UIScreen.main.bounds.height / 2)
+            center = CGPoint(x: UIScreen.main.bounds.width / 2 - r + delta, y: rect.height / 2)
         }
         
         let rect = CGRect(x: center.x - r, y: center.y - r, width: 2 * r, height: 2 * r)


### PR DESCRIPTION
Thank you for this very nice library.
When using ConcentricOnboardingView in modal, the background color of the Button is misaligned.
The reason is that the position of Circle is based on the screen size.
This fixed code 9004c2f0b569c6504b535d0cce39ae13e6cbf79b calculates the y-axis position of the button by frame size, not by screen size.


<img src="https://github.com/exyte/ConcentricOnboarding/assets/72431055/9c357408-98a5-4ead-8b1e-3b1801fbe7dd" height="500px">

```swift
struct ContentView: View {
    
    @State private var isModal = false
    
    var body: some View {
        Button(action:{
            isModal.toggle()
        }){
            Text("Button")
        }.sheet(isPresented: $isModal){
            ConcentricOnboardingView(pageContents: [(AnyView(Text("Hello")),.blue),
                                                    (AnyView(Text("Hello2")),.green)])
        }
    }
}
```

Below is my environment.
+ iOS 16.4 emulator
+ Xcode  14.3
+ ConcentricOnboarding 1.0.4